### PR TITLE
change publish message example

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,25 +372,18 @@ adam = mySystem.User("adam@clearblade.com", "a13st0rm")
 # Use Adam to access a messaging client
 mqtt = mySystem.Messaging(adam)
 
-
-# Set up callback function
-def on_connect(client, userdata, flags, rc):
-    # When we connect to the broker, start publishing our data to the keelhauled topic
-    for i in range(20):
-        if i%2==0:
-            payload = "yo"
-        else:
-            payload = "ho"
-        client.publish("keelhauled", payload)
-        time.sleep(1)
-
-
-# Connect callback to client
-mqtt.on_connect = on_connect
-
-# Connect and spin for 30 seconds before disconnecting
+# Connect 
 mqtt.connect()
-time.sleep(30)
+
+# When we connect to the broker, start publishing our data to the keelhauled topic
+for i in range(20):
+    if i%2==0:
+        payload = "yo"
+    else:
+        payload = "ho"
+    client.publish("keelhauled", payload)
+    time.sleep(1)
+
 mqtt.disconnect()
 ```
 ---


### PR DESCRIPTION
In the code example of publishing MQTT messages, the platform receives all the messages at the same time after on_connect callback function return, because the background thread to publish messages is blocked in callback function.

When we call connect(), loop_start() function is also called to start a background thread that will process outgoing and incoming message buffer and trigger callback function. So, while callback function is executing, this background thread is blocked, as a result, it cannot send messages we published in the buffer.

The right way to write publish code is to put publish in the main thread, after calling connect(). We don’t need to wait for connect() because it is a blocking function and we already have default on-connect function in SDK to return error messages.