### PR TITLE
Add clean session param

### DIFF
--- a/clearblade/Messaging.py
+++ b/clearblade/Messaging.py
@@ -143,4 +143,5 @@ class Messaging:
         except:
             logMsg = "unstringifiable object"
         cbLogs.info("Publishing", logMsg, "to", channel, ".")
-        self.__mqttc.publish(channel, message, qos, retain)
+        resp = self.__mqttc.publish(channel, message, qos, retain)
+        return resp

--- a/clearblade/Messaging.py
+++ b/clearblade/Messaging.py
@@ -25,7 +25,7 @@ def parse_url(url):
 
 class Messaging:
     def __init__(self, user=None, port=1883, keepalive=30, url="", client_id="", use_tls=False):
-        # mqtt client
+        # mqtt client.
         self.__mqttc = (client_id != "" and mqtt.Client(client_id=client_id)) or mqtt.Client(client_id=uuid.uuid4().hex)
         self.__mqttc.username_pw_set(user.token, user.system.systemKey)
 


### PR DESCRIPTION
Returns a MQTTMessageInfo which expose the following attributes and methods:

1. rc, the result of the publishing. It could be MQTT_ERR_SUCCESS to indicate success, MQTT_ERR_NO_CONN if the client is not currently connected, or MQTT_ERR_QUEUE_SIZE when max_queued_messages_set is used to indicate that message is neither queued nor sent.

2. mid is the message ID for the publish request. The mid value can be used to track the publish request by checking against the mid argument in the on_publish() callback if it is defined. wait_for_publish may be easier depending on your use-case.

3. wait_for_publish() will block until the message is published. It will raise ValueError if the message is not queued (rc == MQTT_ERR_QUEUE_SIZE), or a RuntimeError if there was an error when publishing, most likely due to the client not being connected.

4. is_published returns True if the message has been published. It will raise ValueError if the message is not queued (rc == MQTT_ERR_QUEUE_SIZE), or a RuntimeError if there was an error when publishing, most likely due to the client not being connected.

A ValueError will be raised if topic is None, has zero length or is invalid (contains a wildcard), if qos is not one of 0, 1 or 2, or if the length of the payload is greater than 268435455 bytes.