### PR TITLE
feat: offer standard logging module usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ from clearblade.ClearBladeCore import cbLogs
 cbLogs.DEBUG = False
 cbLogs.MQTT_DEBUG = False
 ```
+**NOTE:**
+
+If you want output of messages to be controlled by python's logging module, set the `cbLogs.USE_LOGS = True`. The MQTT messages are written to the `Mqtt` named logger and `CB` logs are written to the `CB` named logger. So for a configuration that outputs all debug information via the standard library logging module, use:
+
+```python
+from clearblade.ClearBladeCore import cbLogs
+
+# logging via the standard logging module
+cbLogs.DEBUG = True
+cbLogs.MQTT_DEBUG = True
+cbLogs.USE_LOGS = True
+```
+
 ---
 ### Systems
 On the ClearBlade Platform, you develop IoT solutions through **systems**. 

--- a/clearblade/cbLogs.py
+++ b/clearblade/cbLogs.py
@@ -1,8 +1,22 @@
 from __future__ import print_function, absolute_import
 # set these variables to false to disable the logs
 # (import cbLogs to your project and set it from there)
+import logging
+
+
 DEBUG = True
 MQTT_DEBUG = True
+USE_LOGS = False  # default to false to preserve existing behavior
+LEVEL_TO_LOG_LEVEL = {
+    1: logging.INFO,
+    2: logging.INFO,   # NOTE: no equivelent to "notice"
+    4: logging.WARNING,
+    8: logging.ERROR,
+    16: logging.DEBUG,
+}
+
+
+cb_logger = logging.getLogger("CB")
 
 
 class prettyText:
@@ -21,26 +35,41 @@ class prettyText:
 
 def error(*args):
     # Errors should always be shown
-    print(prettyText.bold + prettyText.red + "CB Error:" + prettyText.endColor, " ".join(args))
+    if USE_LOGS:
+        cb_logger.error(" ".join(args))
+    else:
+        print(prettyText.bold + prettyText.red + "CB Error:" + prettyText.endColor, " ".join(args))
+
 
 def warn(*args):
     # Warnings should always be shown
-    print(prettyText.bold + prettyText.yellow + "CB Warning: " + prettyText.endColor, " ".join(args))
+    if USE_LOGS:
+        cb_logger.warning(" ".join(args))
+    else:
+        print(prettyText.bold + prettyText.yellow + "CB Warning: " + prettyText.endColor, " ".join(args))
+
 
 def info(*args):
     if DEBUG:  # extra info should not always be shown
-        print(prettyText.bold + prettyText.blue + "CB Info:" + prettyText.endColor, " ".join(args))
+        if USE_LOGS:
+            cb_logger.debug(" ".join(args))
+        else:
+            print(prettyText.bold + prettyText.blue + "CB Info:" + prettyText.endColor, " ".join(args))
 
 
 def mqtt(level, data):
     if MQTT_DEBUG:
-        if level == 1:
-            print(prettyText.bold + prettyText.cyan + "Mqtt Info:" + prettyText.endColor, data)
-        elif level == 2:
-            print(prettyText.bold + prettyText.green + "Mqtt Notice:" + prettyText.endColor, data)
-        elif level == 4:
-            print(prettyText.bold + prettyText.yellow + "Mqtt Warning:" + prettyText.endColor, data)
-        elif level == 8:
-            print(prettyText.bold + prettyText.red + "Mqtt Error:" + prettyText.endColor, data)
-        elif level == 16:
-            print(prettyText.bold + prettyText.purple + "Mqtt Debug:" + prettyText.endColor, data)
+        if USE_LOGS:
+            mqtt_logger = logging.getLogger("Mqtt")
+            mqtt_logger.log(LEVEL_TO_LOG_LEVEL.get(level, logging.INFO), data)
+        else:
+            if level == 1:
+                print(prettyText.bold + prettyText.cyan + "Mqtt Info:" + prettyText.endColor, data)
+            elif level == 2:
+                print(prettyText.bold + prettyText.green + "Mqtt Notice:" + prettyText.endColor, data)
+            elif level == 4:
+                print(prettyText.bold + prettyText.yellow + "Mqtt Warning:" + prettyText.endColor, data)
+            elif level == 8:
+                print(prettyText.bold + prettyText.red + "Mqtt Error:" + prettyText.endColor, data)
+            elif level == 16:
+                print(prettyText.bold + prettyText.purple + "Mqtt Debug:" + prettyText.endColor, data)


### PR DESCRIPTION
Added a new flag to allow using python's standard library logging module.

Default is `False` so that existing behavior of the library is unchanged.

When set to `True` and the other debug options are set to `True`, it outputs to logging with named loggers `Mqtt` and `CB` (to stay consistent to the print statements). This allows for more precise control over logging output/format/filtering using the standard python logging configuration.

REAMDE.md is also updated to reflect the new setting.